### PR TITLE
Automate website push to LRZ GItLab

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,6 +64,6 @@ jobs:
       - name: Push branches
         run: |
           # push them
-          git push --force lrz_gitlab_remote --gh-pages
+          git push --force lrz_gitlab_remote gh-pages
         
       

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,3 +23,27 @@ jobs:
           target: gh-pages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+         
+          
+      - name: Set up SSH
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          
+      - name: Add LRZ GitLab remote
+        run: |
+          git remote add lrz_gitlab_remote git@gitlab.lrz.de:lmu-open-science-center/lmu-osc-website.git
+          git remote -v
+          
+      - name: Fetch and push all branches to remote
+        run: |
+          git fetch origin --all
+          
+      - name: Push all branches to new remote
+        run: |
+          # Loop through all local branches and push them to lrz_gitlab_remote
+          for branch in $(git branch -r | grep -v '\->' | sed 's/  origin\///'); do
+            git push lrz_gitlab_remote origin/$branch:$branch
+          done
+        
+      

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,10 +27,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          
           
-      - name: Set up SSH
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      # - name: Set up SSH
+      #   uses: webfactory/ssh-agent@v0.9.0
+      #   with:
+      #     ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          
+      - name: Set up SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_github_gitlab_connection
+          chmod 600 ~/.ssh/id_github_gitlab_connection
+          ssh-keyscan -t ed25519 gitlab.lrz.de >> ~/.ssh/known_hosts
           
       - name: Add LRZ GitLab remote
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,9 +48,9 @@ jobs:
           git remote add lrz_gitlab_remote git@gitlab.lrz.de:lmu-open-science-center/lmu-osc-website.git
           git remote -v
           
-      # - name: Fetch and push all branches to remote
-      #   run: |
-      #     git fetch --all
+      - name: Fetch all branches from origin
+        run: |
+          git fetch --all
           
       - name: Push all branches to new remote
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,13 +39,6 @@ jobs:
           # You can also verify the fingerprint manually (optional)
           # ssh-keyscan gitlab.lrz.de | tee -a ~/.ssh/known_hosts
           
-      # - name: Set up SSH key
-      #   run: |
-      #     mkdir -p ~/.ssh
-      #     echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_github_gitlab_connection
-      #     chmod 600 ~/.ssh/id_github_gitlab_connection
-      #     ssh-keyscan -t ed25519 gitlab.lrz.de >> ~/.ssh/known_hosts
-          
       - name: Check LRZ connection
         run: |
           ssh -T git@gitlab.lrz.de
@@ -61,9 +54,13 @@ jobs:
           
       - name: Push all branches to new remote
         run: |
+          # list branches
+          git branch
+          # push them
+          git push lrz_gitlab_remote --all
           # Loop through all local branches and push them to lrz_gitlab_remote
-          for branch in $(git branch -r | grep -v '\->' | sed 's/  origin\///'); do
-            git push lrz_gitlab_remote origin/$branch:$branch
-          done
+          # for branch in $(git branch -r | grep -v '\->' | sed 's/  origin\///'); do
+          #   git push lrz_gitlab_remote origin/$branch:$branch
+          # done
         
       

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -30,6 +28,11 @@ jobs:
     needs: build-deploy
     runs-on: ubuntu-latest
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
       - name: Set up SSH
         uses: webfactory/ssh-agent@v0.9.0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,11 +54,15 @@ jobs:
           git remote add lrz_gitlab_remote git@gitlab.lrz.de:lmu-open-science-center/lmu-osc-website.git
           git remote -v
           
-      - name: Fetch and push all branches to new remote
+      - name: Fetch branches
         run: |
-          # list branches
-          git pull origin gh-pages
+          git status
+          git fetch origin gh-pages
           git branch
+          git status
+        
+      - name: Push branches
+        run: |
           # push them
           git push --force lrz_gitlab_remote --gh-pages
         

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,10 @@ jobs:
           chmod 600 ~/.ssh/id_github_gitlab_connection
           ssh-keyscan -t ed25519 gitlab.lrz.de >> ~/.ssh/known_hosts
           
+      - name: Check LRZ connection
+        run: |
+          ssh -T git@gitlab.lrz.de
+          
       - name: Add LRZ GitLab remote
         run: |
           git remote add lrz_gitlab_remote git@gitlab.lrz.de:lmu-open-science-center/lmu-osc-website.git

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          
-          
+  push-to-lrz-gitlab:
+    needs: build-deploy
+    runs-on: ubuntu-latest
+    steps:
       - name: Set up SSH
         uses: webfactory/ssh-agent@v0.9.0
         with:
@@ -48,19 +51,12 @@ jobs:
           git remote add lrz_gitlab_remote git@gitlab.lrz.de:lmu-open-science-center/lmu-osc-website.git
           git remote -v
           
-      - name: Fetch all branches from origin
-        run: |
-          git fetch --all
-          
-      - name: Push all branches to new remote
+      - name: Fetch and push all branches to new remote
         run: |
           # list branches
+          git fetch --all
           git branch
           # push them
           git push lrz_gitlab_remote --all
-          # Loop through all local branches and push them to lrz_gitlab_remote
-          # for branch in $(git branch -r | grep -v '\->' | sed 's/  origin\///'); do
-          #   git push lrz_gitlab_remote origin/$branch:$branch
-          # done
         
       

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,6 +60,6 @@ jobs:
           git pull origin gh-pages
           git branch
           # push them
-          git push lrz_gitlab_remote --all
+          git push --force lrz_gitlab_remote --gh-pages
         
       

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -35,9 +37,9 @@ jobs:
           git remote add lrz_gitlab_remote git@gitlab.lrz.de:lmu-open-science-center/lmu-osc-website.git
           git remote -v
           
-      - name: Fetch and push all branches to remote
-        run: |
-          git fetch --all
+      # - name: Fetch and push all branches to remote
+      #   run: |
+      #     git fetch --all
           
       - name: Push all branches to new remote
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,16 +54,19 @@ jobs:
           git remote add lrz_gitlab_remote git@gitlab.lrz.de:lmu-open-science-center/lmu-osc-website.git
           git remote -v
           
-      - name: Fetch branches
+      - name: Fetch and checkout branch
         run: |
           git status
+          git branch
           git fetch origin gh-pages
+          git branch
+          git checkout -b gh-pages origin/gh-pages
           git branch
           git status
         
-      - name: Push branches
+      - name: Push gh-pages to LRZ
         run: |
-          # push them
+          # push gh-pages
           git push --force lrz_gitlab_remote gh-pages
         
       

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,13 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
           
+      - name: Add GitLab to known hosts
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan gitlab.lrz.de >> ~/.ssh/known_hosts
+          # You can also verify the fingerprint manually (optional)
+          # ssh-keyscan gitlab.lrz.de | tee -a ~/.ssh/known_hosts
+          
       # - name: Set up SSH key
       #   run: |
       #     mkdir -p ~/.ssh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Fetch and push all branches to new remote
         run: |
           # list branches
-          git fetch --all
+          git pull origin gh-pages
           git branch
           # push them
           git push lrz_gitlab_remote --all

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,17 +27,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          
           
-      # - name: Set up SSH
-      #   uses: webfactory/ssh-agent@v0.9.0
-      #   with:
-      #     ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Set up SSH
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
           
-      - name: Set up SSH key
-        run: |
-          mkdir -p ~/.ssh
-          echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_github_gitlab_connection
-          chmod 600 ~/.ssh/id_github_gitlab_connection
-          ssh-keyscan -t ed25519 gitlab.lrz.de >> ~/.ssh/known_hosts
+      # - name: Set up SSH key
+      #   run: |
+      #     mkdir -p ~/.ssh
+      #     echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_github_gitlab_connection
+      #     chmod 600 ~/.ssh/id_github_gitlab_connection
+      #     ssh-keyscan -t ed25519 gitlab.lrz.de >> ~/.ssh/known_hosts
           
       - name: Check LRZ connection
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
           
       - name: Fetch and push all branches to remote
         run: |
-          git fetch origin --all
+          git fetch --all
           
       - name: Push all branches to new remote
         run: |


### PR DESCRIPTION
The Quarto Publish workflow includes an additional job that pushes the `gh-pages` branch to the LRZ GitLab repo for the website every time a change to `main` is made