### PR TITLE
Cross-referencing example

### DIFF
--- a/example-cross-refs.qmd
+++ b/example-cross-refs.qmd
@@ -5,21 +5,21 @@ number-depth: 3
 number-offset: [2,0,0]
 ---
 
-# A header here {#sec:header1}
+# A header here {#sec-header1}
 
-This is a section with a header. We can refer to it using `\@ref(sec:header1)`.
+This is a section with a header. We can refer to it using `@sec-header1`. For example, @sec-header1
 
 ## A l2 header here
 
 ::: {.panel-tabset}
 
-# A Level one header here {#sec:header2}
+# A Level one header here {#sec-header2}
 
-## A Level two header here {#sec:header4}
+## A Level two header here {#sec-header4}
 
 
-# Another Level one header here {#sec:header3}
+# Another Level one header here {#sec-header3}
 
-## Another Level two header here {#sec:header5}
+## Another Level two header here {#sec-header5}
 
 :::


### PR DESCRIPTION
@Riyaaa1 here's an example of having headers within a .panel-tabset that have anchors/links. They can be referenced like normal. However, it seems that linking to a hidden header (in this case `## Another Level two header here {#sec:header5}
`) does not actually open the tab where it is placed.