### PR TITLE
Add citation to handbook page

### DIFF
--- a/training/research-cycle-handbook.qmd
+++ b/training/research-cycle-handbook.qmd
@@ -7,6 +7,22 @@ format:
   html:
     page-layout: article
     anchor-sections: false
+
+citation:
+  author:
+    - family: Ihle Malika
+      given: Malika
+      affiliation: "LMU Open Science Center, LMU Munich"
+    - family: Gupta Reema
+      given: Reema
+      affiliation: "LMU Open Science Center, LMU Munich"
+    - family: Schönbrodt Felix
+      given: Felix
+      affiliation: "LMU Open Science Center, LMU Munich"
+  type: article-journal
+  container-title: "Journal of Data Science Software"
+  doi: "10.23915/reprodocs.00010"
+  url: https://example.com/summarizing-output
 ---
 
 #### What is this handbook?


### PR DESCRIPTION
There is not a native approach to moving the location of the BibTex/citation output as it is processed as an appendix (i.e. for the end of the page). But the included discussion has a possible workaround if it is absolutely necessary: https://github.com/orgs/quarto-dev/discussions/6609

<img width="940" height="561" alt="Screenshot 2026-03-26 at 4 44 17 PM" src="https://github.com/user-attachments/assets/73231aee-cd6c-4904-a71f-d34f340a39da" />