### PR TITLE
Create custom 404 page with toolbox redirect notice

### DIFF
--- a/404.qmd
+++ b/404.qmd
@@ -10,12 +10,36 @@ const path = window.location.pathname;
 
 if (path.startsWith('/toolbox')) {
   document.getElementById('content').innerHTML = `
-    <h2>Toolbox Notice</h2>
-    <p>This section of the site is no longer available.</p>
+    <h2>Looking for the Toolbox?</h2>
+    <p>
+      The Toolbox section has been retired and is no longer available at this address.
+      All resources previously found in the Toolbox have been moved to our
+      <a href="/training/">Training</a> section, where you will find our self-learning
+      catalog, tutorials, and other open science resources.
+    </p>
+    <p>
+      Please update any bookmarks or links to point to the
+      <a href="/training/">Training section</a> of the LMU Open Science Center website.
+    </p>
   `;
 } else {
   document.getElementById('content').innerHTML = `
-    <p>The page you’re looking for doesn’t exist.</p>
+    <h2>Oops -- we can't find that page!</h2>
+    <p>
+      The page you're looking for doesn't exist or may have been moved.
+      Here are some helpful links to get you back on track:
+    </p>
+    <ul>
+      <li><a href="/">Home</a></li>
+      <li><a href="/about/">About the LMU Open Science Center</a></li>
+      <li><a href="/training/">Training resources</a></li>
+      <li><a href="/events/">Events</a></li>
+    </ul>
+    <p>
+      If you followed a link and ended up here, please feel free to
+      <a href="https://github.com/lmu-osc/lmu-osc.github.io/issues">let us know</a>
+      so we can fix it.
+    </p>
   `;
 }
 </script>


### PR DESCRIPTION
Adds a custom `404.qmd` page that provides user-friendly messaging when a page is not found.

## Changes Made

- **Toolbox path notice**: Visitors arriving at any `/toolbox/*` URL are shown a dedicated message explaining that the Toolbox section has been retired and directing them to the [Training section](/training/) instead, with a request to update bookmarks and links.
- **General 404 message**: All other missing pages display a friendly "Oops — we can't find that page!" message with helpful navigation links to Home, About, Training, and Events, plus an invitation to report broken links via a GitHub issue.

The path detection is handled client-side via `window.location.pathname`, so no server-side configuration is required beyond placing the `404.qmd` file at the site root.