### PR TITLE
Direct special advisor card links to their people page

### DIFF
--- a/people/listings/active-special-advisors-listing.ejs
+++ b/people/listings/active-special-advisors-listing.ejs
@@ -32,12 +32,12 @@ const specialAdvisorFaculty = (typeof activeSpecialAdvisorMembership?.faculty ==
 <div class="card" <%= metadataAttrs(item) %>>
 <div class="row g-0">
 <div class="d-flex justify-content-center align-items-center p-2 mt-3">
-<a href="<%= item.links[0].url %>" target="_blank">
+<a href="<%= item.path %>" >
 <img src="people/<%= item.photo || '/images/default.svg' %>" class="profile-image" alt="Profile photo of <%= item.name %>">
 </a>
 </div>
 <div class="card-body">
-<a class="card-title" href="<%= item.links[0].url %>" target="_blank"><%= item.name %></a>
+<a class="card-title" href="<%= item.path %>" ><%= item.name %></a>
 <div class="card-subtitle card-subtitle-one mb-0 text-muted">
   <%= item.academic_title %>
 </div>


### PR DESCRIPTION
Previous approach was to take the first available link from any `links` added to their profile